### PR TITLE
Separate test dependencies from normal dependencies

### DIFF
--- a/buildout/buildout.cfg
+++ b/buildout/buildout.cfg
@@ -41,5 +41,6 @@ APP_PATH = ${buildout:directory}
 recipe = zc.recipe.testrunner
 eggs =
     ${plone:eggs}
+    seantis.dir.base [tests]
 defaults = ['--auto-color', '--auto-progress']
 environment = testenv

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ import os
 
 version = '1.2b1'
 
+tests_require = [
+    'collective.testcaselayer',
+    ]
+
 setup(name='seantis.dir.base',
       version=version,
       description="Directory module for Plone using Dexterity",
@@ -28,7 +32,6 @@ setup(name='seantis.dir.base',
           'Plone',
           'plone.app.dexterity',
           'collective.autopermission',
-          'collective.testcaselayer',
           'plone.behavior',
           'plone.directives.form',
           'collective.dexteritytextindexer',
@@ -41,6 +44,8 @@ setup(name='seantis.dir.base',
           'collective.geo.openlayers',
           'collective.geo.kml',
       ],
+      tests_require=tests_require,
+      extras_require=dict(tests=tests_require),
       entry_points="""
       [z3c.autoinclude.plugin]
       target = plone


### PR DESCRIPTION
The test dependencies should not be installed in production.
