### PR TITLE
Add onegove-approved badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,14 @@ An example, offering a directory of contacts can be found here: https://github.c
 
 This module is probably only really useful for anyone if used as a base to build on. By itself it only offers the categorization and search functionalities.
 
+
+.. figure:: http://onegov.ch/approved.png/image
+   :align: right
+   :target: http://onegov.ch/community/zertifizierte-module/seantis.dir.base
+
+   Certified: 01/2013
+
+
 Build Status
 ============
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@
 1.2 (beta)
 ---
 
+- onegov.ch approved: add badge to readme.
 - Makes catalog adaptable for better customization
 - Adds maps to items using collective.geo
 - Refactors design. Base does no longer hold it's own type.


### PR DESCRIPTION
Adds a onegov.ch-approved badge to the readme.
(github does not support align-right at the moment, on pypi it will be aligned right)
